### PR TITLE
Fix: Ensure null or non-finite radius is treated as zero power.

### DIFF
--- a/Calculo_de_matrices.html
+++ b/Calculo_de_matrices.html
@@ -262,20 +262,23 @@ const opticalMatrices = {
         if (n <= 0) throw new Error("Índice 'n' debe ser > 0.");
         return [[1, 0], [d/n, 1]];
     },
-    surface: function(R, n1, n2) { // Refracción
-        if (n1 <= 0 || n2 <= 0) throw new Error("Índices 'n1' y 'n2' deben ser > 0.");
-        // safeRadiusTerm is not used here as per Python's direct (nt-ni)/R
-        const P_int = (R === Infinity || !isFinite(R) || R === 0) ? 0 : (n2 - n1) / R;
-        if (R === 0 && (n2 - n1) !== 0) throw new Error("Radio 'R' no puede ser cero para una superficie refractiva con cambio de índice.");
-        return [[1, -P_int], [0, 1]];
-    },
-    reflectionSurface: function(R_mirror, n_medium = 1.0) { // Reflexión
-        if (n_medium <= 0) throw new Error("Índice 'n_medium' debe ser > 0.");
-        // safeRadiusTerm is not used here as per Python's direct (2*ni)/R
-        const A = (R_mirror === Infinity || !isFinite(R_mirror) || R_mirror === 0) ? 0 : (2 * n_medium) / R_mirror;
-        if (R_mirror === 0 && n_medium !== 0) throw new Error("Radio 'R_mirror' no puede ser cero para un espejo en un medio con índice.");
-        return [[1, A], [0, 1]];
-    },
+surface: function(R, n1, n2) { // Refracción
+    if (n1 <= 0 || n2 <= 0) throw new Error("Índices 'n1' y 'n2' deben ser > 0.");
+    if (R === 0 && (n2 - n1) !== 0) {
+        throw new Error("Radio 'R' no puede ser cero para una superficie refractiva con cambio de índice, ya que implicaría poder infinito.");
+    }
+    const P_int = (typeof R === 'number' && isFinite(R) && R !== 0) ? (n2 - n1) / R : 0;
+    return [[1, -P_int], [0, 1]];
+},
+reflectionSurface: function(R_mirror, n_medium = 1.0) { // Reflexión
+    if (n_medium <= 0) throw new Error("Índice 'n_medium' debe ser > 0.");
+    // Adjusted error message for clarity, and check n_medium is not strictly necessary if it's already checked to be > 0
+    if (R_mirror === 0) { // Simplified condition as n_medium > 0 is already guaranteed.
+        throw new Error("Radio 'R_mirror' no puede ser cero para un espejo, ya que implicaría poder infinito.");
+    }
+    const P_reflect_term = (typeof R_mirror === 'number' && isFinite(R_mirror) && R_mirror !== 0) ? (2 * n_medium) / R_mirror : 0;
+    return [[1, P_reflect_term], [0, 1]]; // Assuming A was equivalent to P_reflect_term
+},
     thinLens: function({f, P, n = 1.0}) { // n is the surrounding medium index
         let Pow_len_mm_inv; // Power in mm^-1 (Potencia focal)
         if (n <= 0) throw new Error("Índice 'n' del medio debe ser > 0.");
@@ -299,14 +302,21 @@ const opticalMatrices = {
         if (d_lente < 0) throw new Error("Espesor 'd_lente' no puede ser negativo.");
 
         // P1: Power of the first surface
-        const P1 = (R1 === Infinity || !isFinite(R1) || R1 === 0) ? 0 : (n_lente - n_inc) / R1;
-        if (R1 === 0 && (n_lente - n_inc) !== 0) throw new Error("Radio 'R1' no puede ser cero para la primera superficie con cambio de índice.");
+        if (R1 === 0 && (n_lente - n_inc) !== 0) {
+            throw new Error("Radio 'R1' no puede ser cero para la primera superficie con cambio de índice, ya que implicaría poder infinito.");
+        }
+        const P1 = (typeof R1 === 'number' && isFinite(R1) && R1 !== 0) ? (n_lente - n_inc) / R1 : 0;
 
         // P2: Power of the second surface
-        const P2 = (R2 === Infinity || !isFinite(R2) || R2 === 0) ? 0 : (n_salida - n_lente) / R2;
-        if (R2 === 0 && (n_salida - n_lente) !== 0) throw new Error("Radio 'R2' no puede ser cero para la segunda superficie con cambio de índice.");
+        if (R2 === 0 && (n_salida - n_lente) !== 0) {
+            throw new Error("Radio 'R2' no puede ser cero para la segunda superficie con cambio de índice, ya que implicaría poder infinito.");
+        }
+        const P2 = (typeof R2 === 'number' && isFinite(R2) && R2 !== 0) ? (n_salida - n_lente) / R2 : 0;
 
-        if (n_lente === 0) throw new Error("Índice 'n_lente' no puede ser cero para el cálculo de la lente gruesa.");
+        // n_lente === 0 check is critical for denominators involving n_lente.
+        // This check should ideally be done before P1 or P2 if they depended on n_lente in a division, but they don't directly.
+        // It's crucial for the matrix elements M11, M12, M21, M22.
+        if (n_lente === 0) throw new Error("Índice 'n_lente' no puede ser cero para el cálculo de la lente gruesa, resultaría en división por cero.");
 
         const M11 = 1 - ((P2 * d_lente) / n_lente);
         const M12 = ((P1 * P2 * d_lente) / n_lente) - P1 - P2;


### PR DESCRIPTION
The previous calculation for optical power in refraction, reflection, and thick lens matrices did not correctly handle cases where the radius of curvature (R) was `null`. This could occur if data was imported with `null` values or due to other edge cases. When R was `null`, it was treated as division by `null`, resulting in `Infinity` for the power term, and subsequently `-Infinity` in the matrix element.

This commit modifies the power calculation in:
- `opticalMatrices.surface`
- `opticalMatrices.reflectionSurface`
- `opticalMatrices.thickLens`

The power terms (e.g., `P_int`, `P_reflect_term`, `P1`, `P2`) are now calculated using the logic: `(typeof R === 'number' && isFinite(R) && R !== 0) ? (relevant_power_formula) / R : 0;`

This ensures that if R is `null`, `undefined`, `NaN`, `Infinity`, or any other non-finite number, the power contribution is correctly treated as zero. The specific error conditions for `R === 0` (implying infinite power if indices change) are preserved and checked before this calculation.

This change fixes the reported issue where a refraction surface with R effectively infinite (represented or inputted mistakenly as `null`) would yield `[1, -Infinity; 0, 1]` instead of the correct `[1, 0; 0, 1]`.